### PR TITLE
fix crash when encountering other players

### DIFF
--- a/modmain.lua
+++ b/modmain.lua
@@ -68,17 +68,18 @@ local function TrackBellBonding(player_classified)
 end
 
 AddPlayerPostInit(function(player)
-    player:ListenForEvent("itemget", OnItemGet)
-
     player:DoTaskInTime(0, function(inst)
-        inst.player_classified:ListenForEvent("isperformactionsuccessdirty", TrackBellBonding)
+        if inst == GLOBAL.ThePlayer then
+            inst:ListenForEvent("itemget", OnItemGet)
+            inst.player_classified:ListenForEvent("isperformactionsuccessdirty", TrackBellBonding)
 
-        local bell = inst.replica.inventory:FindItem(function(v)
-            return v:HasTags(LINKED_BELL_TAGS)
-        end)
-        print("BCS: found bell in inventory: " .. tostring(bell))
-        if bell ~= nil then
-            OnItemGet(inst, { item = bell })
+            local bell = inst.replica.inventory:FindItem(function(v)
+                return v:HasTags(LINKED_BELL_TAGS)
+            end)
+            print("BCS: found bell in inventory: " .. tostring(bell))
+            if bell ~= nil then
+                OnItemGet(inst, { item = bell })
+            end
         end
     end)
 end)


### PR DESCRIPTION
The game crashes if there's any player in your screen since it attempts to hook their nonexistent `player_classified` prefab.

Other off-topic feedback (not related to the PR):

- This mod's action detection seems to be broken when you're not holding down your click to queue actions. In my experience, it works 0% of the time when clicking individually (this applies to both types of feeding as well as brushing), although it does meet the advertised 90% accuracy when queuing.
- The mod doesn't have separate saves for multiple beefalo but I suppose that's quite niche.
- Syncing for vomiting does not sync the hunger to max for some reason.
- The delta time for hunger seems a bit too high; the hunger ticks down in increments of 5, which feels awkward.
- Might be nice to have an subtle indicator of when you can brush your beefalo. 100% accurate brushing detection should be possible since you get 1 wool on top of the durability loss.

Cool stuff overall, though, it was fun reading the random hacks you implemented. :P